### PR TITLE
Check the environment for the GitHub token secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Set `allow-repeats: false` in order to post and update a single comment. This co
 ## 📒 Options
 
 ### `secret-name` (optional, string)
-The environment variable that contains the value of the GitHub API token. If not set, the plugin will try to get the URL from the default configuration.
+The name of the environment variable or Buildkite Secret that contains the value of the GitHub API token.
 
 Default: `GITHUB_TOKEN`
 

--- a/hooks/environment
+++ b/hooks/environment
@@ -27,4 +27,13 @@ build_dir="$(dirname "$d")"
 
 echo "~~~ :electric_plug: Building plugin hooks"
 echo "Building for ${HOST_GOOS} on ${HOST_GOARCH}"
-cd "${build_dir}" && go build -o hooks/pre-exit
+
+run_go () {
+    if ! command -v go >/dev/null 2>&1; then
+        docker run -w /opt -v .:/opt "${BUILDKITE_PLUGIN_PR_COMMENTER_GO_DOCKER_IMAGE:-golang:alpine}" go "$@"
+    else
+        go "$@"
+    fi
+}
+
+cd "${build_dir}" && run_go build -o hooks/pre-exit

--- a/internal/secret/secret.go
+++ b/internal/secret/secret.go
@@ -2,13 +2,20 @@ package secret
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 )
 
 var ExecCommand = exec.Command
+var OsLookupEnv = os.LookupEnv
 
 func GetSecret(name string) (string, error) {
+	fromEnv, found := OsLookupEnv(name)
+	if found {
+		return fromEnv, nil
+	}
+
 	cmd := ExecCommand("buildkite-agent", "secret", "get", name)
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/secret/secret_test.go
+++ b/internal/secret/secret_test.go
@@ -11,6 +11,13 @@ func TestGetSecret(t *testing.T) {
 	oldExecCmd := secret.ExecCommand
 	defer func() { secret.ExecCommand = oldExecCmd }()
 
+	oldOsLookupEnv := secret.OsLookupEnv
+	defer func() { secret.OsLookupEnv = oldOsLookupEnv }()
+
+	secret.OsLookupEnv = func(name string) (string, bool) {
+		return "", false
+	}
+
 	secret.ExecCommand = func(command string, args ...string) *exec.Cmd {
 		return exec.Command("echo", "foobar")
 	}
@@ -21,6 +28,32 @@ func TestGetSecret(t *testing.T) {
 	}
 
 	want := "foobar"
+	if got != want {
+		t.Fatalf("wanted %s, got %s", want, got)
+	}
+}
+
+func TestGetSecretFromEnv(t *testing.T) {
+	oldExecCmd := secret.ExecCommand
+	defer func() { secret.ExecCommand = oldExecCmd }()
+
+	oldOsLookupEnv := secret.OsLookupEnv
+	defer func() { secret.OsLookupEnv = oldOsLookupEnv }()
+
+	secret.OsLookupEnv = func(name string) (string, bool) {
+		return name + "_FOUND", true
+	}
+
+	secret.ExecCommand = func(command string, args ...string) *exec.Cmd {
+		return exec.Command("false")
+	}
+
+	got, err := secret.GetSecret("MOCK_SECRET")
+	if err != nil {
+		t.Fatalf("error getting secret value: %s", err)
+	}
+
+	want := "MOCK_SECRET_FOUND"
 	if got != want {
 		t.Fatalf("wanted %s, got %s", want, got)
 	}

--- a/plugin.yml
+++ b/plugin.yml
@@ -19,3 +19,7 @@ configuration:
     message-id:
       type: string
       description: "Unique ID of the message to be posted, used to identify existing comments (allow-repeats: false). Use if plugin is used more than once in same job."
+    go-docker-image:
+      type: string
+      default: "golang:alpine"
+      description: "Docker image to use to run Go to build the plugin hooks. Only necessary if Go is not already present on the agent."

--- a/plugin.yml
+++ b/plugin.yml
@@ -10,6 +10,8 @@ configuration:
       type: string
     secret-name:
       type: string
+      description: "Name of the Buildkite secret or environment variable containing the GitHub token."
+      default: "GITHUB_TOKEN"
     allow-repeats:
       type: boolean
       description: "Allow identical comments to be posted every time the plugin is run"
@@ -17,5 +19,3 @@ configuration:
     message-id:
       type: string
       description: "Unique ID of the message to be posted, used to identify existing comments (allow-repeats: false). Use if plugin is used more than once in same job."
-  required:
-    - secret-name


### PR DESCRIPTION
The change in this PR allows using ephemeral tokens like those for a GitHub App, which cannot be stored in Buildkite secrets (as they are ephemeral and generated as part of the pipeline or step).
